### PR TITLE
bodymen email+password validation

### DIFF
--- a/src/api/password-reset/index.js
+++ b/src/api/password-reset/index.js
@@ -3,6 +3,7 @@ export PasswordReset, { schema } from './model'
 import { masterman } from '~/services/auth'
 import { middleware as body } from 'bodymen'
 import { schema as userSchema } from 'a/user/model'
+import { passwordValidator, emailValidator } from '~/utils/validator'
 import {
     create,
     show,
@@ -86,7 +87,15 @@ router.post(
     '',
     masterman(),
     body({
-        email,
+        email: {
+            ...email,
+            validate: (value) => (
+                {
+                    valid: emailValidator.test(value),
+                    message: 'Email is invalid'
+                }
+            )
+        },
     }),
     create
 )
@@ -127,7 +136,15 @@ router.post(
 router.patch(
     '/:token',
     body({
-        password
+        password: {
+            ...password,
+            validate: (value) => (
+                {
+                    valid: passwordValidator.test(value),
+                    message: 'Password is invalid'
+                }
+            )
+        },
     }),
     update
 )

--- a/src/api/user/index.js
+++ b/src/api/user/index.js
@@ -4,10 +4,10 @@ import { middleware as body } from 'bodymen'
 import { masterman, validateUserBeforeCreate } from 's/auth'
 import { schema } from './model'
 export User, { schema } from './model'
+import { passwordValidator, emailValidator } from '~/utils/validator'
 
 import {
     index,
-    showMe,
     show,
     create,
     update,
@@ -110,8 +110,24 @@ router.post(
     masterman(),
     validateUserBeforeCreate(),
     body({
-        email,
-        password,
+        email: {
+            ...email,
+            validate: (value) => (
+                {
+                    valid: emailValidator.test(value),
+                    message: 'Email is invalid'
+                }
+            )
+        },
+        password: {
+            ...password,
+            validate: (value) => (
+                {
+                    valid: passwordValidator.test(value),
+                    message: 'Password is invalid'
+                }
+            )
+        },
         name,
         picture,
         role
@@ -201,7 +217,15 @@ router.put('/:id', body({ name, picture }), update)
 router.put(
     '/:id/password',
     body({
-        password
+        password: {
+            ...password,
+            validate: (value) => (
+                {
+                    valid: passwordValidator.test(value),
+                    message: 'Password is invalid'
+                }
+            )
+        },
     }),
     updatePassword
 )

--- a/src/api/user/model.js
+++ b/src/api/user/model.js
@@ -19,12 +19,18 @@ const userSchema = new Schema(
             unique: true,
             trim: true,
             lowercase: true,
-            match: emailValidator
+            validate: {
+                validator: (value) => emailValidator.test(value),
+                message: props => 'Email is invalid'
+            }
         },
         password: {
             type: String,
-            match: passwordValidator,
             required: true,
+            validate: {
+                validator: (value) => passwordValidator.test(value),
+                message: props => 'Password is invalid'
+            }
         },
         name: {
             type: String,

--- a/src/config.js
+++ b/src/config.js
@@ -107,6 +107,6 @@ const config = {
         }
     }
 }
-console.log(config.all.env)
+
 module.exports = Object.assign(config.all, config[config.all.env])
 export default module.exports

--- a/src/config.js
+++ b/src/config.js
@@ -107,6 +107,6 @@ const config = {
         }
     }
 }
-
+console.log(config.all.env)
 module.exports = Object.assign(config.all, config[config.all.env])
 export default module.exports


### PR DESCRIPTION
bodymen now returns _slightly_ better validation error messages.

For some reason bodymen does not support the native mongoose validate properties. That's why the validation seems kinda redundant :/ 

Since we cannot access the response (for i18n) the error messages are also always in english...